### PR TITLE
[FIX] Fix plugin to scan entire file for matching suitename

### DIFF
--- a/src/main/java/com/solutions/it/exemplar/SuiteUtil.java
+++ b/src/main/java/com/solutions/it/exemplar/SuiteUtil.java
@@ -59,9 +59,8 @@ public class SuiteUtil {
     try {
 
       String line = br.readLine();
-      int maxLineSearch = 25;
 
-      for (int i = 0; i < maxLineSearch; i++) {
+      while(line != null){
 
         String suiteName = getSuiteName(line);
         if (suiteName != null) {


### PR DESCRIPTION
@acwatson is there a reason you only search 25 lines for the suitename?

We have tests with large data sets at the top of the files, so would like the plugin to scan the whole file.

Also, are there any specific instructions I need in order to build this project locally?
