### PR TITLE
Add support for string declarations using ` char

### DIFF
--- a/src/main/java/com/solutions/it/exemplar/SuiteUtil.java
+++ b/src/main/java/com/solutions/it/exemplar/SuiteUtil.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SuiteUtil {
 
-  private static final String SUITE_REGEX = "^(describe\\((\\'|\\\")(.*)(\\'|\\\").*$)";
+  private static final String SUITE_REGEX = "^(describe\\((\\'|\\\"|\\`)(.*)(\\'|\\\"|\\`).*$)";
   private static final Pattern SUITE_PATTERN = Pattern.compile(SUITE_REGEX);
   private static final Logger LOG = LoggerFactory.getLogger(SuiteUtil.class);
 


### PR DESCRIPTION
This is a suggested solution to solve detection of string declarations with the ` character, ES6-style.

Please let me know if anything else needs to be updated (docs, tests, pom.xml).